### PR TITLE
Implement blockage in private channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ servers as cluster to increase the message delivery speed/throughput.
 - chat in public channels with any users (1 connection/channel)
 - chat in private channels with another user (1 connection/user)
 - chat in group channel with members (1 connection/user)
+- user blockage in private channels
 
 ## Supported Protocols
 

--- a/doc/chat-detail/README.md
+++ b/doc/chat-detail/README.md
@@ -16,7 +16,7 @@
 
 ![image](private-chat.png)
 
-## Chat in group channel (Work in progress...)
+## Chat in group channel
 
 - A group channel allows any members to chat online. A user should 
 be invited to the channel first by any member, and the user should 
@@ -25,3 +25,12 @@ accept the invitation to become a member.
 - Query history messages by channel id.
 
 ![image](group-chat.png)
+
+## Block a private channel
+
+If userA block userB, 
+
+- a flag of the private channel in db will be marked
+- any future msgs from userB to userA is invisible, unblocked will not take these msgs back
+- publish msg endpoint will return 403 when userB sends msg to userA (actually do not persist/deliver msgs)
+- userB can still get new msgs from userA until userB block userA

--- a/src/main/java/com/joejoe2/chat/config/JwtConfig.java
+++ b/src/main/java/com/joejoe2/chat/config/JwtConfig.java
@@ -1,9 +1,8 @@
 package com.joejoe2.chat.config;
 
-import java.security.interfaces.RSAPublicKey;
-
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
+import java.security.interfaces.RSAPublicKey;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -16,7 +15,7 @@ public class JwtConfig {
   private RSAPublicKey publicKey;
 
   @Bean
-  public JwtParser parser(){
+  public JwtParser parser() {
     return Jwts.parserBuilder().setSigningKey(publicKey).build();
   }
 }

--- a/src/main/java/com/joejoe2/chat/controller/PrivateChannelController.java
+++ b/src/main/java/com/joejoe2/chat/controller/PrivateChannelController.java
@@ -7,16 +7,14 @@ import com.joejoe2.chat.data.PageRequestWithSince;
 import com.joejoe2.chat.data.SliceList;
 import com.joejoe2.chat.data.channel.SliceOfPrivateChannel;
 import com.joejoe2.chat.data.channel.profile.PrivateChannelProfile;
+import com.joejoe2.chat.data.channel.request.ChannelBlockRequest;
 import com.joejoe2.chat.data.channel.request.ChannelRequest;
 import com.joejoe2.chat.data.channel.request.CreatePrivateChannelRequest;
 import com.joejoe2.chat.data.channel.request.SubscribeRequest;
 import com.joejoe2.chat.data.message.PrivateMessageDto;
 import com.joejoe2.chat.data.message.SliceOfMessage;
 import com.joejoe2.chat.data.message.request.PublishMessageRequest;
-import com.joejoe2.chat.exception.AlreadyExist;
-import com.joejoe2.chat.exception.ChannelDoesNotExist;
-import com.joejoe2.chat.exception.InvalidOperation;
-import com.joejoe2.chat.exception.UserDoesNotExist;
+import com.joejoe2.chat.exception.*;
 import com.joejoe2.chat.service.channel.PrivateChannelService;
 import com.joejoe2.chat.service.message.PrivateMessageService;
 import com.joejoe2.chat.utils.AuthUtil;
@@ -83,6 +81,8 @@ public class PrivateChannelController {
       return new ResponseEntity<>(new ErrorMessageResponse(e.getMessage()), HttpStatus.NOT_FOUND);
     } catch (InvalidOperation e) {
       return new ResponseEntity<>(new ErrorMessageResponse(e.getMessage()), HttpStatus.FORBIDDEN);
+    } catch (BlockedException e) {
+      return ResponseEntity.ok().build();
     }
   }
 
@@ -246,5 +246,40 @@ public class PrivateChannelController {
   public Object subscribe(@ParameterObject @Valid SubscribeRequest request)
       throws UserDoesNotExist {
     return channelService.subscribe(AuthUtil.currentUserDetail().getId());
+  }
+
+  @Operation(summary = "set block state of private channel")
+  @AuthenticatedApi
+  @SecurityRequirement(name = "jwt")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "403",
+            description = "you are not the member in target channel",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorMessageResponse.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "target channel is not exist",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorMessageResponse.class))),
+        @ApiResponse(responseCode = "200", content = @Content),
+      })
+  @RequestMapping(path = "/blockage", method = RequestMethod.POST)
+  public ResponseEntity<Object> setBlockage(@Valid @RequestBody ChannelBlockRequest request)
+      throws UserDoesNotExist {
+    try {
+      channelService.setBlockage(
+          AuthUtil.currentUserDetail().getId(), request.getChannelId(), request.getIsBlocked());
+      return ResponseEntity.ok().build();
+    } catch (ChannelDoesNotExist e) {
+      return new ResponseEntity<>(new ErrorMessageResponse(e.getMessage()), HttpStatus.NOT_FOUND);
+    } catch (InvalidOperation e) {
+      return new ResponseEntity<>(new ErrorMessageResponse(e.getMessage()), HttpStatus.FORBIDDEN);
+    }
   }
 }

--- a/src/main/java/com/joejoe2/chat/controller/PrivateChannelController.java
+++ b/src/main/java/com/joejoe2/chat/controller/PrivateChannelController.java
@@ -273,7 +273,7 @@ public class PrivateChannelController {
   public ResponseEntity<Object> setBlockage(@Valid @RequestBody ChannelBlockRequest request)
       throws UserDoesNotExist {
     try {
-      channelService.setBlockage(
+      channelService.block(
           AuthUtil.currentUserDetail().getId(), request.getChannelId(), request.getIsBlocked());
       return ResponseEntity.ok().build();
     } catch (ChannelDoesNotExist e) {

--- a/src/main/java/com/joejoe2/chat/controller/PrivateChannelController.java
+++ b/src/main/java/com/joejoe2/chat/controller/PrivateChannelController.java
@@ -48,7 +48,7 @@ public class PrivateChannelController {
       value = {
         @ApiResponse(
             responseCode = "403",
-            description = "current user is not a member" + " of target channel",
+            description = "current user is blocked or not a member" + " of target channel",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -79,10 +79,8 @@ public class PrivateChannelController {
       return ResponseEntity.ok(message);
     } catch (ChannelDoesNotExist e) {
       return new ResponseEntity<>(new ErrorMessageResponse(e.getMessage()), HttpStatus.NOT_FOUND);
-    } catch (InvalidOperation e) {
+    } catch (InvalidOperation | BlockedException e) {
       return new ResponseEntity<>(new ErrorMessageResponse(e.getMessage()), HttpStatus.FORBIDDEN);
-    } catch (BlockedException e) {
-      return ResponseEntity.ok().build();
     }
   }
 

--- a/src/main/java/com/joejoe2/chat/data/channel/request/ChannelBlockRequest.java
+++ b/src/main/java/com/joejoe2/chat/data/channel/request/ChannelBlockRequest.java
@@ -1,0 +1,24 @@
+package com.joejoe2.chat.data.channel.request;
+
+import com.joejoe2.chat.validation.constraint.UUID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChannelBlockRequest {
+  @Schema(description = "id of target channel")
+  @UUID(message = "invalid channel id !")
+  @NotNull(message = "channelId is missing !")
+  private String channelId;
+
+  @Schema(description = "block state of target channel")
+  @NotNull(message = "isBlocked is missing !")
+  private Boolean isBlocked;
+}

--- a/src/main/java/com/joejoe2/chat/exception/BlockedException.java
+++ b/src/main/java/com/joejoe2/chat/exception/BlockedException.java
@@ -1,0 +1,7 @@
+package com.joejoe2.chat.exception;
+
+public class BlockedException extends Exception {
+  public BlockedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/joejoe2/chat/models/PrivateChannel.java
+++ b/src/main/java/com/joejoe2/chat/models/PrivateChannel.java
@@ -48,10 +48,10 @@ public class PrivateChannel extends TimeStampBase {
   String uniqueUserIds;
 
   @Column(columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
-  private boolean isUser1Blocked;
+  private boolean isFirstUserBlocked;
 
   @Column(columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
-  private boolean isUser2Blocked;
+  private boolean isSecondUserBlocked;
 
   @PrePersist
   void prePersist() {
@@ -81,18 +81,24 @@ public class PrivateChannel extends TimeStampBase {
     return getMembers().stream().filter(u -> !member.getId().equals(u.getId())).findFirst().get();
   }
 
-  public void setBlockage(User user, boolean isBlock) {
+  /**
+   * block or unblock the user
+   *
+   * @param user target user, cannot {@link #addMessage} until unblocked
+   * @param isBlock block or unblock
+   */
+  public void block(User user, boolean isBlock) {
     int pos = uniqueUserIds.indexOf(user.getId().toString());
     if (pos == 0) {
-      isUser1Blocked = isBlock;
+      isFirstUserBlocked = isBlock;
     } else if (pos > 0) {
-      isUser2Blocked = isBlock;
+      isSecondUserBlocked = isBlock;
     }
   }
 
   public boolean isBlocked(User user) {
     int pos = uniqueUserIds.indexOf(user.getId().toString());
-    return pos != -1 && (pos == 0 ? isUser1Blocked : isUser2Blocked);
+    return pos != -1 && (pos == 0 ? isFirstUserBlocked : isSecondUserBlocked);
   }
 
   public void addMessage(User from, String message) throws InvalidOperation, BlockedException {

--- a/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
@@ -24,7 +24,6 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.nats.client.Connection;
 import io.nats.client.Dispatcher;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;

--- a/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelService.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelService.java
@@ -67,15 +67,15 @@ public interface PrivateChannelService {
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
   /**
-   * set blockage to another user in the channel
+   * let user block or unblock the channel(another user)
    *
-   * @param ofUserId
-   * @param channelId
-   * @param isBlock
+   * @param userId user id of the initiator
+   * @param channelId id of target channel
+   * @param isBlock block or unblock
    * @throws UserDoesNotExist
    * @throws ChannelDoesNotExist
    * @throws InvalidOperation user is not in members of target channel
    */
-  void setBlockage(String ofUserId, String channelId, boolean isBlock)
+  void block(String userId, String channelId, boolean isBlock)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 }

--- a/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelService.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelService.java
@@ -61,8 +61,21 @@ public interface PrivateChannelService {
    * @return profile of target channel
    * @throws UserDoesNotExist
    * @throws ChannelDoesNotExist
-   * @throws InvalidOperation target user is not in members of target channel
+   * @throws InvalidOperation user is not in members of target channel
    */
   PrivateChannelProfile getChannelProfile(String ofUserId, String channelId)
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
+
+  /**
+   * set blockage to another user in the channel
+   *
+   * @param ofUserId
+   * @param channelId
+   * @param isBlock
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation user is not in members of target channel
+   */
+  void setBlockage(String ofUserId, String channelId, boolean isBlock)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 }

--- a/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelServiceImpl.java
@@ -294,11 +294,11 @@ public class PrivateChannelServiceImpl implements PrivateChannelService {
   @Override
   @Retryable(value = OptimisticLockingFailureException.class, backoff = @Backoff(delay = 100))
   @Transactional(rollbackFor = Exception.class)
-  public void setBlockage(String ofUserId, String channelId, boolean isBlock)
+  public void block(String userId, String channelId, boolean isBlock)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation {
     User user =
         userRepository
-            .findById(uuidValidator.validate(ofUserId))
+            .findById(uuidValidator.validate(userId))
             .orElseThrow(() -> new UserDoesNotExist("user is not exist !"));
     PrivateChannel channel =
         channelRepository
@@ -307,7 +307,7 @@ public class PrivateChannelServiceImpl implements PrivateChannelService {
     if (!channel.getMembers().contains(user))
       throw new InvalidOperation("user is not in members of the channel !");
 
-    channel.setBlockage(channel.anotherMember(user), isBlock);
+    channel.block(channel.anotherMember(user), isBlock);
     channelRepository.save(channel);
   }
 }

--- a/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/PrivateChannelServiceImpl.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.nats.client.Connection;
 import io.nats.client.Dispatcher;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
@@ -32,7 +31,10 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Slice;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -287,5 +289,25 @@ public class PrivateChannelServiceImpl implements PrivateChannelService {
       throw new InvalidOperation("user is not in members of the channel !");
 
     return new PrivateChannelProfile(channel);
+  }
+
+  @Override
+  @Retryable(value = OptimisticLockingFailureException.class, backoff = @Backoff(delay = 100))
+  @Transactional(rollbackFor = Exception.class)
+  public void setBlockage(String ofUserId, String channelId, boolean isBlock)
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation {
+    User user =
+        userRepository
+            .findById(uuidValidator.validate(ofUserId))
+            .orElseThrow(() -> new UserDoesNotExist("user is not exist !"));
+    PrivateChannel channel =
+        channelRepository
+            .findById(uuidValidator.validate(channelId))
+            .orElseThrow(() -> new ChannelDoesNotExist("channel is not exist !"));
+    if (!channel.getMembers().contains(user))
+      throw new InvalidOperation("user is not in members of the channel !");
+
+    channel.setBlockage(channel.anotherMember(user), isBlock);
+    channelRepository.save(channel);
   }
 }

--- a/src/main/java/com/joejoe2/chat/service/channel/PublicChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/PublicChannelServiceImpl.java
@@ -19,7 +19,6 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.nats.client.Connection;
 import io.nats.client.Dispatcher;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;

--- a/src/main/java/com/joejoe2/chat/service/jwt/JwtServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/jwt/JwtServiceImpl.java
@@ -15,8 +15,7 @@ import org.springframework.stereotype.Service;
 public class JwtServiceImpl implements JwtService {
   @Autowired JwtConfig jwtConfig;
   @Autowired RedisService redisService;
-  @Autowired
-  JwtParser jwtParser;
+  @Autowired JwtParser jwtParser;
 
   private static final Logger logger = LoggerFactory.getLogger(JwtServiceImpl.class);
 

--- a/src/main/java/com/joejoe2/chat/service/message/PrivateMessageService.java
+++ b/src/main/java/com/joejoe2/chat/service/message/PrivateMessageService.java
@@ -3,6 +3,7 @@ package com.joejoe2.chat.service.message;
 import com.joejoe2.chat.data.PageRequest;
 import com.joejoe2.chat.data.SliceList;
 import com.joejoe2.chat.data.message.PrivateMessageDto;
+import com.joejoe2.chat.exception.BlockedException;
 import com.joejoe2.chat.exception.ChannelDoesNotExist;
 import com.joejoe2.chat.exception.InvalidOperation;
 import com.joejoe2.chat.exception.UserDoesNotExist;
@@ -10,7 +11,7 @@ import java.time.Instant;
 
 public interface PrivateMessageService {
   PrivateMessageDto createMessage(String fromUserId, String channelId, String message)
-      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation, BlockedException;
 
   void deliverMessage(PrivateMessageDto message);
 

--- a/src/main/java/com/joejoe2/chat/utils/JwtUtil.java
+++ b/src/main/java/com/joejoe2/chat/utils/JwtUtil.java
@@ -45,7 +45,7 @@ public class JwtUtil {
     try {
       Claims claims = parser.parseClaimsJws(token).getBody();
       return claims.entrySet().stream()
-              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     } catch (Exception e) {
       throw new JwtException(e.getMessage());
     }
@@ -54,7 +54,7 @@ public class JwtUtil {
   private static final String[] REQUIRED_FIELDS = new String[] {"type", "id", "username"};
 
   public static UserDetail extractUserDetailFromAccessToken(JwtParser parser, String token)
-          throws InvalidTokenException {
+      throws InvalidTokenException {
     try {
       Map<String, Object> data = JwtUtil.parseToken(parser, token);
       if (Arrays.stream(REQUIRED_FIELDS).anyMatch((f) -> data.get(f) == null)) {

--- a/src/main/resources/db/changelog/2023/10/10-01-changelog.yaml
+++ b/src/main/resources/db/changelog/2023/10/10-01-changelog.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1696145356872-3
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  defaultValueBoolean: false
+                  name: is_user1blocked
+                  type: BOOLEAN
+              - column:
+                  defaultValueBoolean: false
+                  name: is_user2blocked
+                  type: BOOLEAN
+            tableName: private_channel
+  - changeSet:
+      id: 1696145356872-4
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addNotNullConstraint:
+            columnName: is_user1blocked
+            tableName: private_channel
+  - changeSet:
+      id: 1696145356872-6
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addNotNullConstraint:
+            columnName: is_user2blocked
+            tableName: private_channel
+

--- a/src/main/resources/db/changelog/2023/10/10-02-changelog.yaml
+++ b/src/main/resources/db/changelog/2023/10/10-02-changelog.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1696227686045-3
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - renameColumn:
+            columnDataType: BOOLEAN
+            newColumnName: is_first_user_blocked
+            oldColumnName: is_user1blocked
+            tableName: private_channel
+        - renameColumn:
+            columnDataType: BOOLEAN
+            newColumnName: is_second_user_blocked
+            oldColumnName: is_user2blocked
+            tableName: private_channel
+

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/test/changelog/2023/06/06-01-changelog.yaml
   - include:
       file: db/changelog/2023/10/10-01-changelog.yaml
+  - include:
+      file: db/changelog/2023/10/10-02-changelog.yaml

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,5 @@ databaseChangeLog:
       file: db/test/changelog/2023/03/03-01-changelog.yaml
   - include:
       file: db/test/changelog/2023/06/06-01-changelog.yaml
+  - include:
+      file: db/changelog/2023/10/10-01-changelog.yaml

--- a/src/main/resources/db/test/changelog/2023/10/10-01-changelog.yaml
+++ b/src/main/resources/db/test/changelog/2023/10/10-01-changelog.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1696145356872-3
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  defaultValueBoolean: false
+                  name: is_user1blocked
+                  type: BOOLEAN
+              - column:
+                  defaultValueBoolean: false
+                  name: is_user2blocked
+                  type: BOOLEAN
+            tableName: private_channel
+  - changeSet:
+      id: 1696145356872-4
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addNotNullConstraint:
+            columnName: is_user1blocked
+            tableName: private_channel
+  - changeSet:
+      id: 1696145356872-6
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addNotNullConstraint:
+            columnName: is_user2blocked
+            tableName: private_channel
+

--- a/src/main/resources/db/test/changelog/2023/10/10-02-changelog.yaml
+++ b/src/main/resources/db/test/changelog/2023/10/10-02-changelog.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1696227686045-3
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - renameColumn:
+            columnDataType: BOOLEAN
+            newColumnName: is_first_user_blocked
+            oldColumnName: is_user1blocked
+            tableName: private_channel
+        - renameColumn:
+            columnDataType: BOOLEAN
+            newColumnName: is_second_user_blocked
+            oldColumnName: is_user2blocked
+            tableName: private_channel
+

--- a/src/main/resources/db/test/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/test/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/test/changelog/2023/06/06-01-changelog.yaml
   - include:
       file: db/test/changelog/2023/10/10-01-changelog.yaml
+  - include:
+      file: db/test/changelog/2023/10/10-02-changelog.yaml

--- a/src/main/resources/db/test/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/test/changelog/db.changelog-master.yaml
@@ -5,3 +5,5 @@ databaseChangeLog:
       file: db/test/changelog/2023/03/03-01-changelog.yaml
   - include:
       file: db/test/changelog/2023/06/06-01-changelog.yaml
+  - include:
+      file: db/test/changelog/2023/10/10-01-changelog.yaml

--- a/src/test/java/com/joejoe2/chat/controller/GroupChannelWSHandlerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/GroupChannelWSHandlerTest.java
@@ -72,9 +72,9 @@ public class GroupChannelWSHandlerTest {
     userRepository.deleteAll();
   }
 
-  public static class WsClient extends WebSocketClient {
+  public class WsClient extends WebSocketClient {
     CountDownLatch messageLatch;
-    List<String> messages = new ArrayList<>();
+    HashSet<String> messages = new HashSet<>();
 
     public WsClient(URI serverUri) {
       super(serverUri);
@@ -105,6 +105,9 @@ public class GroupChannelWSHandlerTest {
   void subscribe() throws Exception {
     int messageCount = users.length * 2;
     WsClient[] clients = new WsClient[users.length];
+    HashSet<String> messages = new HashSet<>();
+    messages.add("[]");
+
     for (int i = 0; i < users.length; i++) {
       String uri =
           "ws://localhost:8081/ws/channel/group/subscribe?access_token="
@@ -120,8 +123,7 @@ public class GroupChannelWSHandlerTest {
             .channelId(channel.getId().toString())
             .message("msg")
             .build();
-    List<String> messages = new ArrayList<>();
-    messages.add("[]");
+
     for (int i = 0; i < messageCount; i++) {
       String t =
           mockMvc

--- a/src/test/java/com/joejoe2/chat/controller/PrivateChannelControllerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/PrivateChannelControllerTest.java
@@ -194,7 +194,7 @@ class PrivateChannelControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(messageRequest))
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk());
+        .andExpect(status().isForbidden());
     Thread.sleep(1000);
     Mockito.verify(messageService, Mockito.times(0)).deliverMessage(Mockito.any());
     // override mock login

--- a/src/test/java/com/joejoe2/chat/controller/PrivateChannelControllerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/PrivateChannelControllerTest.java
@@ -12,6 +12,7 @@ import com.joejoe2.chat.data.SliceList;
 import com.joejoe2.chat.data.UserDetail;
 import com.joejoe2.chat.data.channel.SliceOfPrivateChannel;
 import com.joejoe2.chat.data.channel.profile.PrivateChannelProfile;
+import com.joejoe2.chat.data.channel.request.ChannelBlockRequest;
 import com.joejoe2.chat.data.channel.request.ChannelRequest;
 import com.joejoe2.chat.data.channel.request.CreatePrivateChannelRequest;
 import com.joejoe2.chat.data.message.MessageDto;
@@ -166,6 +167,65 @@ class PrivateChannelControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.message").exists())
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void testBlockage() throws Exception {
+    ChannelBlockRequest request =
+        ChannelBlockRequest.builder().channelId(channel.getId().toString()).isBlocked(true).build();
+    // user1 block user2
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/channel/private/blockage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    // override mock login
+    mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user2));
+    PublishMessageRequest messageRequest =
+        PublishMessageRequest.builder()
+            .channelId(channel.getId().toString())
+            .message("msg")
+            .build();
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/channel/private/publishMessage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(messageRequest))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    Thread.sleep(1000);
+    Mockito.verify(messageService, Mockito.times(0)).deliverMessage(Mockito.any());
+    // override mock login
+    mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user1));
+    // user1 unblock user2
+    request =
+        ChannelBlockRequest.builder()
+            .channelId(channel.getId().toString())
+            .isBlocked(false)
+            .build();
+    messageRequest =
+        PublishMessageRequest.builder()
+            .channelId(channel.getId().toString())
+            .message("msg")
+            .build();
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/channel/private/blockage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/channel/private/publishMessage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(messageRequest))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+    Thread.sleep(1000);
+    Mockito.verify(messageService, Mockito.times(1)).deliverMessage(Mockito.any());
   }
 
   @Test

--- a/src/test/java/com/joejoe2/chat/service/channel/PrivateChannelServiceTest.java
+++ b/src/test/java/com/joejoe2/chat/service/channel/PrivateChannelServiceTest.java
@@ -198,19 +198,19 @@ class PrivateChannelServiceTest {
     // test IllegalArgument
     assertThrows(
         IllegalArgumentException.class,
-        () -> channelService.setBlockage("invalid_id", "invalid_id", true));
+        () -> channelService.block("invalid_id", "invalid_id", true));
     // test InvalidOperation
     assertThrows(
         InvalidOperation.class,
-        () -> channelService.setBlockage(userC.getId().toString(), channel.getId(), true));
+        () -> channelService.block(userC.getId().toString(), channel.getId(), true));
     // test success
-    channelService.setBlockage(userA.getId().toString(), channel.getId(), true);
+    channelService.block(userA.getId().toString(), channel.getId(), true);
     assertTrue(channelRepository.getById(UUID.fromString(channel.getId())).isBlocked(userB));
-    channelService.setBlockage(userB.getId().toString(), channel.getId(), true);
+    channelService.block(userB.getId().toString(), channel.getId(), true);
     assertTrue(channelRepository.getById(UUID.fromString(channel.getId())).isBlocked(userA));
-    channelService.setBlockage(userA.getId().toString(), channel.getId(), false);
+    channelService.block(userA.getId().toString(), channel.getId(), false);
     assertFalse(channelRepository.getById(UUID.fromString(channel.getId())).isBlocked(userB));
-    channelService.setBlockage(userB.getId().toString(), channel.getId(), false);
+    channelService.block(userB.getId().toString(), channel.getId(), false);
     assertFalse(channelRepository.getById(UUID.fromString(channel.getId())).isBlocked(userA));
   }
 }

--- a/src/test/java/com/joejoe2/chat/service/message/PrivateMessageServiceTest.java
+++ b/src/test/java/com/joejoe2/chat/service/message/PrivateMessageServiceTest.java
@@ -90,22 +90,22 @@ class PrivateMessageServiceTest {
     // prepare channel
     PrivateChannelProfile channel =
         channelService.createChannelBetween(userA.getId().toString(), userC.getId().toString());
-    // test setBlockage
-    channelService.setBlockage(userA.getId().toString(), channel.getId(), true);
+    // test block
+    channelService.block(userA.getId().toString(), channel.getId(), true);
     assertThrows(
         BlockedException.class,
         () -> messageService.createMessage(userC.getId().toString(), channel.getId(), "test"));
     assertDoesNotThrow(
         () -> messageService.createMessage(userA.getId().toString(), channel.getId(), "test"));
-    channelService.setBlockage(userC.getId().toString(), channel.getId(), true);
+    channelService.block(userC.getId().toString(), channel.getId(), true);
     assertThrows(
         BlockedException.class,
         () -> messageService.createMessage(userA.getId().toString(), channel.getId(), "test"));
     // test unblock
-    channelService.setBlockage(userC.getId().toString(), channel.getId(), false);
+    channelService.block(userC.getId().toString(), channel.getId(), false);
     assertDoesNotThrow(
         () -> messageService.createMessage(userA.getId().toString(), channel.getId(), "test"));
-    channelService.setBlockage(userA.getId().toString(), channel.getId(), false);
+    channelService.block(userA.getId().toString(), channel.getId(), false);
     assertDoesNotThrow(
         () -> messageService.createMessage(userC.getId().toString(), channel.getId(), "test"));
   }

--- a/src/test/java/com/joejoe2/chat/service/message/PrivateMessageServiceTest.java
+++ b/src/test/java/com/joejoe2/chat/service/message/PrivateMessageServiceTest.java
@@ -7,6 +7,7 @@ import com.joejoe2.chat.data.PageRequest;
 import com.joejoe2.chat.data.SliceList;
 import com.joejoe2.chat.data.channel.profile.PrivateChannelProfile;
 import com.joejoe2.chat.data.message.PrivateMessageDto;
+import com.joejoe2.chat.exception.BlockedException;
 import com.joejoe2.chat.models.User;
 import com.joejoe2.chat.repository.channel.PrivateChannelRepository;
 import com.joejoe2.chat.repository.message.PrivateMessageRepository;
@@ -82,6 +83,31 @@ class PrivateMessageServiceTest {
     PrivateMessageDto message =
         messageService.createMessage(userA.getId().toString(), channel.getId(), "test");
     assertTrue(messageRepository.existsById(message.getId()));
+  }
+
+  @Test
+  void messageToBlocked() throws Exception {
+    // prepare channel
+    PrivateChannelProfile channel =
+        channelService.createChannelBetween(userA.getId().toString(), userC.getId().toString());
+    // test setBlockage
+    channelService.setBlockage(userA.getId().toString(), channel.getId(), true);
+    assertThrows(
+        BlockedException.class,
+        () -> messageService.createMessage(userC.getId().toString(), channel.getId(), "test"));
+    assertDoesNotThrow(
+        () -> messageService.createMessage(userA.getId().toString(), channel.getId(), "test"));
+    channelService.setBlockage(userC.getId().toString(), channel.getId(), true);
+    assertThrows(
+        BlockedException.class,
+        () -> messageService.createMessage(userA.getId().toString(), channel.getId(), "test"));
+    // test unblock
+    channelService.setBlockage(userC.getId().toString(), channel.getId(), false);
+    assertDoesNotThrow(
+        () -> messageService.createMessage(userA.getId().toString(), channel.getId(), "test"));
+    channelService.setBlockage(userA.getId().toString(), channel.getId(), false);
+    assertDoesNotThrow(
+        () -> messageService.createMessage(userC.getId().toString(), channel.getId(), "test"));
   }
 
   @Test


### PR DESCRIPTION
If userA block userB,
- any future msgs from userB to userA is invisible, unblocked will not take these msgs back
- publish msg endpoint will return 403 when userB sends msg to userA (actually do not persist/deliver msgs)
- userB can still get new msgs from userA until userB block userA