### PR TITLE
Introduce admin and ban in group channel

### DIFF
--- a/src/main/java/com/joejoe2/chat/controller/GroupChannelController.java
+++ b/src/main/java/com/joejoe2/chat/controller/GroupChannelController.java
@@ -267,15 +267,14 @@ public class GroupChannelController {
     return ResponseEntity.ok(new SliceOfMessage<>(sliceList));
   }
 
-  @Operation(summary = "kick off someone in group channel")
+  @Operation(summary = "kick off someone in group channel, only admin can perform this action")
   @AuthenticatedApi
   @SecurityRequirement(name = "jwt")
   @ApiResponses(
       value = {
         @ApiResponse(
             responseCode = "403",
-            description =
-                "you or target user is not in the channel, or only admin can perform this action",
+            description = "you or target user is not in the channel",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -461,15 +460,15 @@ public class GroupChannelController {
     }
   }
 
-  @Operation(summary = "editBanned or unban an user in group channel")
+  @Operation(
+      summary = "editBanned or unban an user in group channel, only admin can perform this action")
   @AuthenticatedApi
   @SecurityRequirement(name = "jwt")
   @ApiResponses(
       value = {
         @ApiResponse(
             responseCode = "403",
-            description =
-                "fail to editBanned or unban the user, or only admin can perform this action",
+            description = "fail to editBanned or unban the user",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -551,14 +550,15 @@ public class GroupChannelController {
     }
   }
 
-  @Operation(summary = "set an user to admin or not in group channel")
+  @Operation(
+      summary = "set an user to admin or not in group channel, only admin can perform this action")
   @AuthenticatedApi
   @SecurityRequirement(name = "jwt")
   @ApiResponses(
       value = {
         @ApiResponse(
             responseCode = "403",
-            description = "fail to set the user to admin, only admin can perform this action",
+            description = "fail to set the user to admin",
             content =
                 @Content(
                     mediaType = "application/json",

--- a/src/main/java/com/joejoe2/chat/controller/GroupChannelController.java
+++ b/src/main/java/com/joejoe2/chat/controller/GroupChannelController.java
@@ -53,7 +53,7 @@ public class GroupChannelController {
       value = {
         @ApiResponse(
             responseCode = "403",
-            description = "current user is not a member" + " of target channel",
+            description = "current user is not a member" + " of target channel or got banned",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -165,7 +165,7 @@ public class GroupChannelController {
             responseCode = "403",
             description =
                 "cannot invite target user into the group channel, you may not in the channel or"
-                    + " target user already in the channel",
+                    + " target user got banned or already in the channel",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -274,7 +274,8 @@ public class GroupChannelController {
       value = {
         @ApiResponse(
             responseCode = "403",
-            description = "ypu or target user is not in the channel",
+            description =
+                "you or target user is not in the channel, or only admin can perform this action",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -467,7 +468,8 @@ public class GroupChannelController {
       value = {
         @ApiResponse(
             responseCode = "403",
-            description = "fail to editBanned or unban the user",
+            description =
+                "fail to editBanned or unban the user, or only admin can perform this action",
             content =
                 @Content(
                     mediaType = "application/json",
@@ -556,7 +558,7 @@ public class GroupChannelController {
       value = {
         @ApiResponse(
             responseCode = "403",
-            description = "fail to set the user to admin or not",
+            description = "fail to set the user to admin, only admin can perform this action",
             content =
                 @Content(
                     mediaType = "application/json",

--- a/src/main/java/com/joejoe2/chat/data/channel/request/EditAdminRequest.java
+++ b/src/main/java/com/joejoe2/chat/data/channel/request/EditAdminRequest.java
@@ -1,0 +1,29 @@
+package com.joejoe2.chat.data.channel.request;
+
+import com.joejoe2.chat.validation.constraint.UUID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EditAdminRequest {
+  @Schema(description = "id of target channel")
+  @UUID(message = "invalid channel id !")
+  @NotNull(message = "channelId is missing !")
+  private String channelId;
+
+  @Schema(description = "id of target user")
+  @UUID(message = "invalid user id")
+  @NotNull(message = "channelId is missing !")
+  private String targetUserId;
+
+  @Schema(description = "set target user to administrator or not")
+  @NotNull(message = "isAdmin is missing !")
+  private Boolean isAdmin;
+}

--- a/src/main/java/com/joejoe2/chat/data/channel/request/EditBannedRequest.java
+++ b/src/main/java/com/joejoe2/chat/data/channel/request/EditBannedRequest.java
@@ -1,0 +1,29 @@
+package com.joejoe2.chat.data.channel.request;
+
+import com.joejoe2.chat.validation.constraint.UUID;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EditBannedRequest {
+  @Schema(description = "id of target channel")
+  @UUID(message = "invalid channel id !")
+  @NotNull(message = "channelId is missing !")
+  private String channelId;
+
+  @Schema(description = "id of target user")
+  @UUID(message = "invalid user id")
+  @NotNull(message = "channelId is missing !")
+  private String targetUserId;
+
+  @Schema(description = "editBanned state of target user")
+  @NotNull(message = "isBanned is missing !")
+  private Boolean isBanned;
+}

--- a/src/main/java/com/joejoe2/chat/models/GroupChannel.java
+++ b/src/main/java/com/joejoe2/chat/models/GroupChannel.java
@@ -214,8 +214,7 @@ public class GroupChannel extends TimeStampBase {
    */
   public void addToAdministrators(User admin, User target) throws InvalidOperation {
     checkActionOnSameUser(admin, target);
-    if (!administrators.contains(admin))
-      throw new InvalidOperation("admin is not an valid administrator in the channel !");
+    checkIsAdmin(admin, false);
     if (!members.contains(target))
       throw new InvalidOperation("target user is not in members of the channel !");
     checkIsNotBanned(target);
@@ -231,8 +230,7 @@ public class GroupChannel extends TimeStampBase {
    */
   public void removeFromAdministrators(User admin, User target) throws InvalidOperation {
     checkActionOnSameUser(admin, target);
-    if (!administrators.contains(admin))
-      throw new InvalidOperation("admin is not an valid administrator in the channel !");
+    checkIsAdmin(admin, false);
 
     administrators.remove(target);
   }

--- a/src/main/java/com/joejoe2/chat/models/GroupChannel.java
+++ b/src/main/java/com/joejoe2/chat/models/GroupChannel.java
@@ -62,7 +62,7 @@ public class GroupChannel extends TimeStampBase {
   }
 
   /**
-   * check the user have admin permissions for actions, note this will always return true if there
+   * Check the user have admin permissions for actions, note this will always return true if there
    * is no administrator due to the old version of the group channel
    *
    * @return true if administrators contains user or there is no administrator
@@ -71,6 +71,12 @@ public class GroupChannel extends TimeStampBase {
     return administrators.contains(user) || administrators.size() == 0;
   }
 
+  /**
+   * Invite a user(who is not banned) to join the group channel. Any member can perform this action.
+   *
+   * @param inviter member
+   * @param invitee an user who is neither banned or a member
+   */
   public void invite(User inviter, User invitee) throws InvalidOperation {
     if (!members.contains(inviter))
       throw new InvalidOperation("inviter is not in members of the channel !");
@@ -86,6 +92,7 @@ public class GroupChannel extends TimeStampBase {
     lastMessage = invitationMessage;
   }
 
+  /** Let admin(see {@link #isAdmin}) kick off target user(who is not an admin). */
   public void kickOff(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot kick off itself !");
     if (!isAdmin(admin))
@@ -116,6 +123,7 @@ public class GroupChannel extends TimeStampBase {
     lastMessage = leaveMessage;
   }
 
+  /** Accept the invitation and join the group channel */
   public void acceptInvitation(User invitee) throws InvalidOperation {
     GroupInvitation invitation = new GroupInvitation(invitee, this);
     if (!invitations.contains(invitation)) throw new InvalidOperation("no invitation !");
@@ -130,8 +138,8 @@ public class GroupChannel extends TimeStampBase {
   }
 
   /**
-   * let admin ban target user(may be not in members), cannot {@link #addMessage} or be {@link
-   * #invite invited} until unbanned
+   * Let admin(see {@link #isAdmin}) ban target user(may be not in members), cannot {@link
+   * #addMessage} or be {@link #invite invited} until unbanned
    */
   public void ban(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot editBanned itself !");
@@ -146,7 +154,7 @@ public class GroupChannel extends TimeStampBase {
     lastMessage = banMessage;
   }
 
-  /** let admin unban target user(may be not in members) */
+  /** Let admin(see {@link #isAdmin}) unban target user(may be not in members) */
   public void unban(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot unban itself !");
     if (!isAdmin(admin))
@@ -159,7 +167,7 @@ public class GroupChannel extends TimeStampBase {
     lastMessage = unbanMessage;
   }
 
-  /** let admin add target user to administrators, no op if target user is an administrator */
+  /** Let admin add target user to administrators, no op if target user is an administrator */
   public void addToAdministrators(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot add itself !");
     if (!administrators.contains(admin))
@@ -172,7 +180,7 @@ public class GroupChannel extends TimeStampBase {
   }
 
   /**
-   * let admin remove target user from administrators, no op if target user is not an administrator
+   * Let admin remove target user from administrators, no op if target user is not an administrator
    */
   public void removeFromAdministrators(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot remove itself !");

--- a/src/main/java/com/joejoe2/chat/models/GroupChannel.java
+++ b/src/main/java/com/joejoe2/chat/models/GroupChannel.java
@@ -77,6 +77,7 @@ public class GroupChannel extends TimeStampBase {
     GroupInvitation invitation = new GroupInvitation(invitee, this);
     if (members.contains(invitee) || invitations.contains(invitation))
       throw new InvalidOperation("invitee is in the channel !");
+    if (banned.contains(invitee)) throw new InvalidOperation("invitee has been banned !");
     checkNumOfMembers();
 
     GroupMessage invitationMessage = GroupMessage.inviteMessage(this, inviter, invitee);
@@ -95,7 +96,6 @@ public class GroupChannel extends TimeStampBase {
       throw new InvalidOperation("target user is not in members of the channel !");
 
     members.remove(target);
-    banned.remove(target);
     GroupMessage leaveMessage = GroupMessage.leaveMessage(this, admin, target);
     messages.add(leaveMessage);
     lastMessage = leaveMessage;
@@ -111,7 +111,6 @@ public class GroupChannel extends TimeStampBase {
 
     members.remove(user);
     administrators.remove(user);
-    banned.remove(user);
     GroupMessage leaveMessage = GroupMessage.leaveMessage(this, user, user);
     messages.add(leaveMessage);
     lastMessage = leaveMessage;
@@ -130,15 +129,16 @@ public class GroupChannel extends TimeStampBase {
     lastMessage = joinMessage;
   }
 
-  /** let admin editBanned target user, cannot {@link #addMessage} until unbanned */
+  /**
+   * let admin ban target user(may be not in members), cannot {@link #addMessage} or be {@link
+   * #invite invited} until unbanned
+   */
   public void ban(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot editBanned itself !");
     if (!isAdmin(admin))
       throw new InvalidOperation("admin is not an valid administrator in the channel !");
     if (administrators.contains(target))
       throw new InvalidOperation("cannot editBanned target because it is an administrator !");
-    if (!members.contains(target))
-      throw new InvalidOperation("target user is not in members of the channel !");
 
     banned.add(target);
     GroupMessage banMessage = GroupMessage.banMessage(this, admin, target);
@@ -146,13 +146,11 @@ public class GroupChannel extends TimeStampBase {
     lastMessage = banMessage;
   }
 
-  /** let admin unban target user */
+  /** let admin unban target user(may be not in members) */
   public void unban(User admin, User target) throws InvalidOperation {
     if (admin.equals(target)) throw new InvalidOperation("cannot unban itself !");
     if (!isAdmin(admin))
       throw new InvalidOperation("admin is not an valid administrator in the channel !");
-    if (!members.contains(target))
-      throw new InvalidOperation("target user is not in members of the channel !");
     if (!banned.contains(target)) throw new InvalidOperation("target user has not been banned !");
 
     banned.remove(target);

--- a/src/main/java/com/joejoe2/chat/models/GroupMessage.java
+++ b/src/main/java/com/joejoe2/chat/models/GroupMessage.java
@@ -46,6 +46,7 @@ public class GroupMessage extends TimeStampBase {
     this.content = content;
   }
 
+  /** generate a message for someone inviting another to join the GroupChannel */
   public static GroupMessage inviteMessage(GroupChannel channel, User inviter, User invitee) {
     GroupMessage message = new GroupMessage();
     message.channel = channel;
@@ -57,6 +58,7 @@ public class GroupMessage extends TimeStampBase {
     return message;
   }
 
+  /** generate a message for someone joining the GroupChannel */
   public static GroupMessage joinMessage(GroupChannel channel, User joiner) {
     GroupMessage message = new GroupMessage();
     message.channel = channel;
@@ -68,6 +70,7 @@ public class GroupMessage extends TimeStampBase {
     return message;
   }
 
+  /** generate a message for someone leaving or kicked off from the GroupChannel */
   public static GroupMessage leaveMessage(GroupChannel channel, User actor, User subject) {
     GroupMessage message = new GroupMessage();
     message.channel = channel;
@@ -76,6 +79,28 @@ public class GroupMessage extends TimeStampBase {
         "{\"id\":\"%s\", \"username\":\"%s\"}"
             .formatted(subject.getId().toString(), subject.getUserName());
     message.messageType = MessageType.LEAVE;
+    return message;
+  }
+
+  public static GroupMessage banMessage(GroupChannel channel, User actor, User subject) {
+    GroupMessage message = new GroupMessage();
+    message.channel = channel;
+    message.from = actor;
+    message.content =
+        "{\"id\":\"%s\", \"username\":\"%s\"}"
+            .formatted(subject.getId().toString(), subject.getUserName());
+    message.messageType = MessageType.BAN;
+    return message;
+  }
+
+  public static GroupMessage unbanMessage(GroupChannel channel, User actor, User subject) {
+    GroupMessage message = new GroupMessage();
+    message.channel = channel;
+    message.from = actor;
+    message.content =
+        "{\"id\":\"%s\", \"username\":\"%s\"}"
+            .formatted(subject.getId().toString(), subject.getUserName());
+    message.messageType = MessageType.UNBAN;
     return message;
   }
 

--- a/src/main/java/com/joejoe2/chat/models/GroupMessage.java
+++ b/src/main/java/com/joejoe2/chat/models/GroupMessage.java
@@ -82,27 +82,28 @@ public class GroupMessage extends TimeStampBase {
     return message;
   }
 
-  /** generate a message for admin banning an user in the GroupChannel */
-  public static GroupMessage banMessage(GroupChannel channel, User actor, User subject) {
+  private static GroupMessage banOrUnBanMessageFormat(
+      GroupChannel channel, User actor, User subject) {
     GroupMessage message = new GroupMessage();
     message.channel = channel;
     message.from = actor;
     message.content =
         "{\"id\":\"%s\", \"username\":\"%s\"}"
             .formatted(subject.getId().toString(), subject.getUserName());
-    message.messageType = MessageType.BAN;
     return message;
   }
 
-  /** generate a message for admin unbanning an user in the GroupChannel */
+  /** generate a message for admin banning an user */
+  public static GroupMessage banMessage(GroupChannel channel, User actor, User subject) {
+    GroupMessage message = banOrUnBanMessageFormat(channel, actor, subject);
+    message.setMessageType(MessageType.BAN);
+    return message;
+  }
+
+  /** generate a message for admin unbanning an user */
   public static GroupMessage unbanMessage(GroupChannel channel, User actor, User subject) {
-    GroupMessage message = new GroupMessage();
-    message.channel = channel;
-    message.from = actor;
-    message.content =
-        "{\"id\":\"%s\", \"username\":\"%s\"}"
-            .formatted(subject.getId().toString(), subject.getUserName());
-    message.messageType = MessageType.UNBAN;
+    GroupMessage message = banOrUnBanMessageFormat(channel, actor, subject);
+    message.setMessageType(MessageType.UNBAN);
     return message;
   }
 

--- a/src/main/java/com/joejoe2/chat/models/GroupMessage.java
+++ b/src/main/java/com/joejoe2/chat/models/GroupMessage.java
@@ -82,6 +82,7 @@ public class GroupMessage extends TimeStampBase {
     return message;
   }
 
+  /** generate a message for admin banning an user in the GroupChannel */
   public static GroupMessage banMessage(GroupChannel channel, User actor, User subject) {
     GroupMessage message = new GroupMessage();
     message.channel = channel;
@@ -93,6 +94,7 @@ public class GroupMessage extends TimeStampBase {
     return message;
   }
 
+  /** generate a message for admin unbanning an user in the GroupChannel */
   public static GroupMessage unbanMessage(GroupChannel channel, User actor, User subject) {
     GroupMessage message = new GroupMessage();
     message.channel = channel;

--- a/src/main/java/com/joejoe2/chat/models/MessageType.java
+++ b/src/main/java/com/joejoe2/chat/models/MessageType.java
@@ -4,7 +4,9 @@ public enum MessageType {
   MESSAGE("MESSAGE"),
   INVITATION("INVITATION"),
   JOIN("JOIN"),
-  LEAVE("LEAVE");
+  LEAVE("LEAVE"),
+  BAN("BAN"),
+  UNBAN("UNBAN");
 
   private final String value;
 

--- a/src/main/java/com/joejoe2/chat/service/channel/GroupChannelService.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/GroupChannelService.java
@@ -2,12 +2,14 @@ package com.joejoe2.chat.service.channel;
 
 import com.joejoe2.chat.data.PageRequest;
 import com.joejoe2.chat.data.SliceList;
+import com.joejoe2.chat.data.UserPublicProfile;
 import com.joejoe2.chat.data.channel.profile.GroupChannelProfile;
 import com.joejoe2.chat.data.message.GroupMessageDto;
 import com.joejoe2.chat.exception.ChannelDoesNotExist;
 import com.joejoe2.chat.exception.InvalidOperation;
 import com.joejoe2.chat.exception.UserDoesNotExist;
 import java.time.Instant;
+import java.util.List;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -64,10 +66,55 @@ public interface GroupChannelService {
   GroupMessageDto acceptInvitationOfChannel(String ofUserId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
-  GroupMessageDto removeFromChannel(String fromUserId, String targetUserId, String channelId)
+  /**
+   * let administrator remove target user from the channel
+   *
+   * @param adminId user id of the administrator
+   * @param targetUserId id of target user
+   * @param channelId id of target channel
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation
+   */
+  GroupMessageDto removeFromChannel(String adminId, String targetUserId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
-  GroupMessageDto leaveChannel(String ofUserId, String channelId)
+  GroupMessageDto leaveChannel(String userId, String channelId)
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
+
+  /**
+   * let administrator of the channel ban or unban target user
+   *
+   * @param adminId user id of the administrator
+   * @param targetUserId id of target user
+   * @param channelId id of target channel
+   * @param isBanned ban or unban
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation
+   */
+  GroupMessageDto editBanned(
+      String adminId, String targetUserId, String channelId, boolean isBanned)
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
+
+  List<UserPublicProfile> getBannedUsers(String userId, String channelId)
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
+
+  List<UserPublicProfile> getAdministrators(String userId, String channelId)
+      throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
+
+  /**
+   * let administrator of the channel set target user to be an administrator or not
+   *
+   * @param adminId user id of the administrator
+   * @param targetUserId id of target user
+   * @param channelId id of target channel
+   * @param isAdmin set target user to be an administrator or not
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation
+   */
+  void editAdministrator(String adminId, String targetUserId, String channelId, boolean isAdmin)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
   /**

--- a/src/main/java/com/joejoe2/chat/service/channel/GroupChannelService.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/GroupChannelService.java
@@ -56,14 +56,16 @@ public interface GroupChannelService {
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
   /**
-   * @param ofUserId invitee id
+   * let user (invitee) join the channel if there is an invitation
+   *
+   * @param userId invitee id
    * @param channelId channel id
    * @return GroupMessageDto join message
    * @throws UserDoesNotExist
    * @throws ChannelDoesNotExist
    * @throws InvalidOperation
    */
-  GroupMessageDto acceptInvitationOfChannel(String ofUserId, String channelId)
+  GroupMessageDto acceptInvitationOfChannel(String userId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
   /**
@@ -79,6 +81,16 @@ public interface GroupChannelService {
   GroupMessageDto removeFromChannel(String adminId, String targetUserId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
+  /**
+   * let user leave the channel
+   *
+   * @param userId member id
+   * @param channelId id of target channel
+   * @return GroupMessageDto leave message
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation
+   */
   GroupMessageDto leaveChannel(String userId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
@@ -97,9 +109,29 @@ public interface GroupChannelService {
       String adminId, String targetUserId, String channelId, boolean isBanned)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
+  /**
+   * let user get all banned users in the channel
+   *
+   * @param userId member id
+   * @param channelId id of target channel
+   * @return list of banned users
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation
+   */
   List<UserPublicProfile> getBannedUsers(String userId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
+  /**
+   * let user get all administrators in the channel
+   *
+   * @param userId member id
+   * @param channelId id of target channel
+   * @return list of administrators
+   * @throws UserDoesNotExist
+   * @throws ChannelDoesNotExist
+   * @throws InvalidOperation
+   */
   List<UserPublicProfile> getAdministrators(String userId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 
@@ -120,24 +152,25 @@ public interface GroupChannelService {
   /**
    * get all group channels of target user with page
    *
-   * @param ofUserId id of target user
+   * @param userId id of target user
    * @param since filter by updateAt >= since
    * @param pageRequest
+   * @return list of channels
    * @throws UserDoesNotExist
    */
   SliceList<GroupChannelProfile> getAllChannels(
-      String ofUserId, Instant since, PageRequest pageRequest) throws UserDoesNotExist;
+      String userId, Instant since, PageRequest pageRequest) throws UserDoesNotExist;
 
   /**
    * get profile of target channel of target user
    *
-   * @param ofUserId id of target user
+   * @param userId id of target user
    * @param channelId id of target channel
    * @return profile of target channel
    * @throws UserDoesNotExist
    * @throws ChannelDoesNotExist
    * @throws InvalidOperation target user is not in members of target channel
    */
-  GroupChannelProfile getChannelProfile(String ofUserId, String channelId)
+  GroupChannelProfile getChannelProfile(String userId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation;
 }

--- a/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
@@ -352,6 +352,10 @@ public class GroupChannelServiceImpl implements GroupChannelService {
           "user with id=%s is not in members of the channel !".formatted(user.getId()));
   }
 
+  private List<UserPublicProfile> collectProfiles(Collection<User> users) {
+    return users.stream().map(UserPublicProfile::new).collect(Collectors.toList());
+  }
+
   @Override
   @Transactional(readOnly = true)
   public List<UserPublicProfile> getBannedUsers(String userId, String channelId)
@@ -359,8 +363,7 @@ public class GroupChannelServiceImpl implements GroupChannelService {
     User user = userService.getUserById(userId);
     GroupChannel channel = getChannelById(channelId);
     checkIsMember(channel, user);
-
-    return channel.getBanned().stream().map(UserPublicProfile::new).collect(Collectors.toList());
+    return collectProfiles(channel.getBanned());
   }
 
   @Override
@@ -370,10 +373,7 @@ public class GroupChannelServiceImpl implements GroupChannelService {
     User user = userService.getUserById(userId);
     GroupChannel channel = getChannelById(channelId);
     checkIsMember(channel, user);
-
-    return channel.getAdministrators().stream()
-        .map(UserPublicProfile::new)
-        .collect(Collectors.toList());
+    return collectProfiles(channel.getAdministrators());
   }
 
   @Override

--- a/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
@@ -346,14 +346,19 @@ public class GroupChannelServiceImpl implements GroupChannelService {
     return new GroupMessageDto(banMessage);
   }
 
+  private void checkIsMember(GroupChannel channel, User user) throws InvalidOperation {
+    if (!channel.getMembers().contains(user))
+      throw new InvalidOperation(
+          "user with id=%s is not in members of the channel !".formatted(user.getId()));
+  }
+
   @Override
   @Transactional(readOnly = true)
   public List<UserPublicProfile> getBannedUsers(String userId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation {
     User user = userService.getUserById(userId);
     GroupChannel channel = getChannelById(channelId);
-    if (!channel.getMembers().contains(user))
-      throw new InvalidOperation("user is not in members of the channel !");
+    checkIsMember(channel, user);
 
     return channel.getBanned().stream().map(UserPublicProfile::new).collect(Collectors.toList());
   }
@@ -364,8 +369,7 @@ public class GroupChannelServiceImpl implements GroupChannelService {
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation {
     User user = userService.getUserById(userId);
     GroupChannel channel = getChannelById(channelId);
-    if (!channel.getMembers().contains(user))
-      throw new InvalidOperation("user is not in members of the channel !");
+    checkIsMember(channel, user);
 
     return channel.getAdministrators().stream()
         .map(UserPublicProfile::new)
@@ -409,8 +413,7 @@ public class GroupChannelServiceImpl implements GroupChannelService {
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation {
     User user = userService.getUserById(userId);
     GroupChannel channel = getChannelById(channelId);
-    if (!channel.getMembers().contains(user))
-      throw new InvalidOperation("user is not in members of the channel !");
+    checkIsMember(channel, user);
 
     return new GroupChannelProfile(channel);
   }

--- a/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
+++ b/src/main/java/com/joejoe2/chat/service/channel/GroupChannelServiceImpl.java
@@ -263,7 +263,6 @@ public class GroupChannelServiceImpl implements GroupChannelService {
   public GroupMessageDto inviteToChannel(String fromUserId, String toUserId, String channelId)
       throws UserDoesNotExist, ChannelDoesNotExist, InvalidOperation {
     User inviter = userService.getUserById(fromUserId);
-    ;
     User invitee = userService.getUserById(toUserId);
     GroupChannel channel = getChannelById(channelId);
 

--- a/src/main/resources/db/changelog/2023/10/10-04-changelog.yaml
+++ b/src/main/resources/db/changelog/2023/10/10-04-changelog.yaml
@@ -1,0 +1,90 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1697336677537-3
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_administrators
+                  name: group_channel_id
+                  type: UUID
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_administrators
+                  name: user_id
+                  type: UUID
+            tableName: group_channels_administrators
+  - changeSet:
+      id: 1697336677537-4
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_banned_users
+                  name: group_channel_id
+                  type: UUID
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_banned_users
+                  name: user_id
+                  type: UUID
+            tableName: group_channels_banned_users
+  - changeSet:
+      id: 1697336677537-5
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: group_channel_id
+            baseTableName: group_channels_administrators
+            constraintName: fk_grochaadm_on_group_channel
+            referencedColumnNames: id
+            referencedTableName: group_channel
+  - changeSet:
+      id: 1697336677537-6
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: group_channels_administrators
+            constraintName: fk_grochaadm_on_user
+            referencedColumnNames: id
+            referencedTableName: account_user
+  - changeSet:
+      id: 1697336677537-7
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: group_channel_id
+            baseTableName: group_channels_banned_users
+            constraintName: fk_grochabanuse_on_group_channel
+            referencedColumnNames: id
+            referencedTableName: group_channel
+  - changeSet:
+      id: 1697336677537-8
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: group_channels_banned_users
+            constraintName: fk_grochabanuse_on_user
+            referencedColumnNames: id
+            referencedTableName: account_user
+

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,3 +11,5 @@ databaseChangeLog:
       file: db/changelog/2023/10/10-02-changelog.yaml
   - include:
       file: db/changelog/2023/10/10-03-changelog.yaml
+  - include:
+      file: db/changelog/2023/10/10-04-changelog.yaml

--- a/src/main/resources/db/test/changelog/2023/10/10-04-changelog.yaml
+++ b/src/main/resources/db/test/changelog/2023/10/10-04-changelog.yaml
@@ -1,0 +1,90 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1697336677537-3
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_administrators
+                  name: group_channel_id
+                  type: UUID
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_administrators
+                  name: user_id
+                  type: UUID
+            tableName: group_channels_administrators
+  - changeSet:
+      id: 1697336677537-4
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_banned_users
+                  name: group_channel_id
+                  type: UUID
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_group_channels_banned_users
+                  name: user_id
+                  type: UUID
+            tableName: group_channels_banned_users
+  - changeSet:
+      id: 1697336677537-5
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: group_channel_id
+            baseTableName: group_channels_administrators
+            constraintName: fk_grochaadm_on_group_channel
+            referencedColumnNames: id
+            referencedTableName: group_channel
+  - changeSet:
+      id: 1697336677537-6
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: group_channels_administrators
+            constraintName: fk_grochaadm_on_user
+            referencedColumnNames: id
+            referencedTableName: account_user
+  - changeSet:
+      id: 1697336677537-7
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: group_channel_id
+            baseTableName: group_channels_banned_users
+            constraintName: fk_grochabanuse_on_group_channel
+            referencedColumnNames: id
+            referencedTableName: group_channel
+  - changeSet:
+      id: 1697336677537-8
+      author: joejoe2 (generated)
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: user_id
+            baseTableName: group_channels_banned_users
+            constraintName: fk_grochabanuse_on_user
+            referencedColumnNames: id
+            referencedTableName: account_user
+

--- a/src/main/resources/db/test/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/test/changelog/db.changelog-master.yaml
@@ -11,3 +11,5 @@ databaseChangeLog:
       file: db/test/changelog/2023/10/10-02-changelog.yaml
   - include:
       file: db/test/changelog/2023/10/10-03-changelog.yaml
+  - include:
+      file: db/test/changelog/2023/10/10-04-changelog.yaml

--- a/src/test/java/com/joejoe2/chat/controller/GroupChannelControllerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/GroupChannelControllerTest.java
@@ -508,6 +508,16 @@ public class GroupChannelControllerTest {
         objectMapper.readValue(result.getResponse().getContentAsString(), GroupMessageDto.class);
     Thread.sleep(1000);
     Mockito.verify(messageService, Mockito.times(1)).deliverMessage(message);
+    // user2 cannot send msg
+    mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user2));
+    mockMvc
+            .perform(
+                    MockMvcRequestBuilders.post("/api/channel/group/publishMessage")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(PublishMessageRequest.builder().channelId(channel.getId().toString()).message("test").build()))
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user1));
     // 1 banned users
     LinkedMultiValueMap<String, String> query = new LinkedMultiValueMap<>();
     query.add("channelId", channel.getId().toString());
@@ -542,6 +552,16 @@ public class GroupChannelControllerTest {
         objectMapper.readValue(result.getResponse().getContentAsString(), GroupMessageDto.class);
     Thread.sleep(1000);
     Mockito.verify(messageService, Mockito.times(1)).deliverMessage(message);
+    // user2 can send msg
+    mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user2));
+    mockMvc
+            .perform(
+                    MockMvcRequestBuilders.post("/api/channel/group/publishMessage")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(PublishMessageRequest.builder().channelId(channel.getId().toString()).message("test").build()))
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+    mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user1));
     // 0 banned users
     result =
         mockMvc

--- a/src/test/java/com/joejoe2/chat/controller/GroupChannelControllerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/GroupChannelControllerTest.java
@@ -511,12 +511,17 @@ public class GroupChannelControllerTest {
     // user2 cannot send msg
     mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user2));
     mockMvc
-            .perform(
-                    MockMvcRequestBuilders.post("/api/channel/group/publishMessage")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(PublishMessageRequest.builder().channelId(channel.getId().toString()).message("test").build()))
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isForbidden());
+        .perform(
+            MockMvcRequestBuilders.post("/api/channel/group/publishMessage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        PublishMessageRequest.builder()
+                            .channelId(channel.getId().toString())
+                            .message("test")
+                            .build()))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
     mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user1));
     // 1 banned users
     LinkedMultiValueMap<String, String> query = new LinkedMultiValueMap<>();
@@ -555,12 +560,17 @@ public class GroupChannelControllerTest {
     // user2 can send msg
     mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user2));
     mockMvc
-            .perform(
-                    MockMvcRequestBuilders.post("/api/channel/group/publishMessage")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(PublishMessageRequest.builder().channelId(channel.getId().toString()).message("test").build()))
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk());
+        .perform(
+            MockMvcRequestBuilders.post("/api/channel/group/publishMessage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        PublishMessageRequest.builder()
+                            .channelId(channel.getId().toString())
+                            .message("test")
+                            .build()))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
     mockAuthUtil.when(AuthUtil::currentUserDetail).thenReturn(new UserDetail(user1));
     // 0 banned users
     result =

--- a/src/test/java/com/joejoe2/chat/controller/GroupChannelWSHandlerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/GroupChannelWSHandlerTest.java
@@ -75,7 +75,7 @@ public class GroupChannelWSHandlerTest {
 
   public class WsClient extends WebSocketClient {
     CountDownLatch messageLatch;
-    HashSet<String> messages = new HashSet<>();
+    Set<String> messages = Collections.synchronizedSet(new HashSet<>());
 
     public WsClient(URI serverUri) {
       super(serverUri);
@@ -144,7 +144,7 @@ public class GroupChannelWSHandlerTest {
     Thread.sleep(1000);
     for (int i = 0; i < users.length; i++) {
       assertTrue(clients[i].isOpen());
-      assertTrue(clients[i].messageLatch.await(5, TimeUnit.SECONDS));
+      assertTrue(clients[i].messageLatch.await(15, TimeUnit.SECONDS));
       assertEquals(messages, clients[i].messages);
       clients[i].closeBlocking();
     }

--- a/src/test/java/com/joejoe2/chat/controller/GroupChannelWSHandlerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/GroupChannelWSHandlerTest.java
@@ -59,7 +59,8 @@ public class GroupChannelWSHandlerTest {
       accessTokens[i] = JwtUtil.generateAccessToken(privateKey, "jti", "issuer", users[i], exp);
     }
     userRepository.saveAll(Arrays.stream(users).toList());
-    channel = new GroupChannel(Set.of(users));
+    channel = new GroupChannel(users[0]);
+    channel.getMembers().addAll(Set.of(users));
     channelRepository.save(channel);
     for (int i = 0; i < users.length; i++) {
       accessTokens[i] = JwtUtil.generateAccessToken(privateKey, "jti", "issuer", users[i], exp);

--- a/src/test/java/com/joejoe2/chat/controller/PrivateChannelWSHandlerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/PrivateChannelWSHandlerTest.java
@@ -74,7 +74,7 @@ public class PrivateChannelWSHandlerTest {
   }
 
   public static class WsClient extends WebSocketClient {
-    HashSet<String> messages = new HashSet<>();
+    Set<String> messages = Collections.synchronizedSet(new HashSet<>());
     CountDownLatch countDownLatch;
 
     public WsClient(URI serverUri, CountDownLatch countDownLatch) {
@@ -132,7 +132,7 @@ public class PrivateChannelWSHandlerTest {
     }
     // test success
     assertTrue(client.isOpen());
-    client.countDownLatch.await(5, TimeUnit.SECONDS);
+    client.countDownLatch.await(15, TimeUnit.SECONDS);
     assertEquals(messages, client.messages);
     client.closeBlocking();
   }

--- a/src/test/java/com/joejoe2/chat/controller/PublicChannelWSHandlerTest.java
+++ b/src/test/java/com/joejoe2/chat/controller/PublicChannelWSHandlerTest.java
@@ -22,7 +22,6 @@ import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,7 +71,7 @@ class PublicChannelWSHandlerTest {
   }
 
   public static class WsClient extends WebSocketClient {
-    HashSet<String> messages = new HashSet<>();
+    Set<String> messages = Collections.synchronizedSet(new HashSet<>());
 
     CountDownLatch countDownLatch;
 
@@ -98,7 +97,6 @@ class PublicChannelWSHandlerTest {
   }
 
   @Test
-  @Disabled
   void subscribe() throws Exception {
     String uri =
         "ws://localhost:8081/ws/channel/public/subscribe?access_token="
@@ -132,7 +130,7 @@ class PublicChannelWSHandlerTest {
     }
     // test success
     assertTrue(client.isOpen());
-    client.countDownLatch.await(5, TimeUnit.SECONDS);
+    client.countDownLatch.await(15, TimeUnit.SECONDS);
     assertEquals(messages, client.messages);
     client.closeBlocking();
   }


### PR DESCRIPTION
In order to add the "ban" function in the group channel, the following rules have been added/adjusted:
1. an admin can add/remove members to/from the admin list
3. an admin can ban/unban members, the banned users cannot send msg to the channel or be invited again
4. an admin can kick off members(except for other admin)
6. old group channels did not record admin list so every member could perform "kick-off", "ban/unban"
7. added APIs: "editAdmin", "admin", "editBanned", "banned"